### PR TITLE
Add support for file attachments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 micronautVersion=3.2.3
-kotlinVersion=1.5.31
+kotlinVersion=1.6.20
 kapt.incremental.apt=false
 logbackVersion=1.2.5
 logbackEncoderVersion=6.6

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/EmailDTO.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/EmailDTO.kt
@@ -3,5 +3,17 @@ package no.nav.arbeidsplassen.emailer.api.v1
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EmailDTO(val identifier: String?, val recipient: String, val subject: String, val content: String, val type: String)
+data class EmailDTO(
+    val identifier: String?,
+    val recipient: String,
+    val subject: String,
+    val content: String,
+    val type: String,
+    val attachments: List<AttachmentDto> = listOf()
+)
 
+data class AttachmentDto(
+    val name: String,
+    val contentType: String,
+    val base64Content: String
+)

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
@@ -3,10 +3,10 @@ package no.nav.arbeidsplassen.emailer.api.v1
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.annotation.Post
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
+import no.nav.arbeidsplassen.emailer.azure.dto.Attachment
 import no.nav.arbeidsplassen.emailer.azure.dto.MailContentType
 import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
 import org.slf4j.LoggerFactory
@@ -24,8 +24,9 @@ class SendMailController(private val emailServiceAzure: EmailServiceAzure) {
     fun sendMail(@Body email: EmailDTO): HttpResponse<String> {
         val id = email.identifier ?: UUID.randomUUID().toString()
         LOG.info("Got email request with id: ${id}")
+        val attachments = email.attachments.map { Attachment(it.name, it.contentType, it.base64Content) }
         emailServiceAzure.sendSimpleMessage(email.recipient, email.subject,
-            MailContentType.valueOf(email.type),email.content, id)
+            MailContentType.valueOf(email.type),email.content, id, attachments)
         return HttpResponse.created("Created")
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/dto/Email.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/dto/Email.kt
@@ -1,8 +1,12 @@
 package no.nav.arbeidsplassen.emailer.azure.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class Email(val message:Message, val saveToSentItems:Boolean=false)
 
-data class Message(val subject: String, val body: Body, val toRecipients: List<Recipient> = listOf<Recipient>())
+data class Message(val subject: String, val body: Body, val toRecipients: List<Recipient> = listOf<Recipient>(),
+                   @JsonInclude(JsonInclude.Include.NON_EMPTY) val attachments: List<Attachment>)
 
 data class Body(val contentType: MailContentType = MailContentType.TEXT, val content: String)
 
@@ -10,6 +14,13 @@ data class Recipient(val emailAddress: Address)
 
 data class Address(val address: String)
 
+data class Attachment(
+    val name: String,
+    val contentType: String,
+    val contentBytes: String,
+    @JsonProperty("@odata.type")
+    val odataType: String = "#microsoft.graph.fileAttachment",
+    )
 
 enum class MailContentType {
     TEXT,

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/EmailServiceAzure.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/EmailServiceAzure.kt
@@ -43,8 +43,8 @@ class EmailServiceAzure(private val aadProperties: AzureADProperties, @Client("S
     private var token: AADToken? = null
 
 
-    fun sendSimpleMessage(to: String, subject: String, contentType: MailContentType, content: String, id: String) {
-        val email = Email(Message(subject, Body(contentType, content), listOf(Recipient(Address(to.trim())))))
+    fun sendSimpleMessage(to: String, subject: String, contentType: MailContentType, content: String, id: String, attachments: List<Attachment> = listOf()) {
+        val email = Email(Message(subject, Body(contentType, content), listOf(Recipient(Address(to.trim()))), attachments))
         try {
             sendMailUsingURLConnectionWithRetry(email, id)
 //            sendMail(email, id)

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/azure/EmailerIT.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/azure/EmailerIT.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsplassen.emailer.azure
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import no.nav.arbeidsplassen.emailer.azure.dto.Attachment
 import no.nav.arbeidsplassen.emailer.azure.dto.MailContentType
 import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
 import org.junit.jupiter.api.Test
@@ -13,5 +14,14 @@ class EmailerIT(private val emailServiceAzure: EmailServiceAzure) {
     fun sendEmailAzure() {
         emailServiceAzure.sendSimpleMessage("recipient@somewhere.com", "Dette er en test",
             MailContentType.TEXT, "Dette er en test", UUID.randomUUID().toString());
+    }
+
+    @Test
+    fun sendEmailAzureWithAttachment() {
+        val encodeToByteArray: ByteArray = "Hei!".encodeToByteArray()
+        val attachment = Attachment("test.txt", "plain/text", Base64.getEncoder().encodeToString(encodeToByteArray))
+
+        emailServiceAzure.sendSimpleMessage("recipient@somewhere.com", "Dette er en test",
+            MailContentType.TEXT, "Dette er en test", UUID.randomUUID().toString(), listOf(attachment));
     }
 }


### PR DESCRIPTION
Lägger till stöd för att skicka med vedlegg vid e-mail-utskick. Datan skickas Base64-kodad.
Uppgraderat Kotlin till 1.6.30. Lyckades inte starta applikationen med Kotlin 1.5, troligen på missmatch mellan Kotlin-Java-versioner.