### PR TITLE
Intermediate email storage

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,19 +6,23 @@ on:
       - ".gitignore"
       - "LICENCE"
       - "CODEOWNERS"
+      - ".nais/alerts.yaml"
+      - ".github/workflows/alerts.yml"
     branches:
-      - main
+      - '**'
 jobs:
   call-workflow:
-    uses: navikt/pam-deploy/.github/workflows/deploy-dev.yml@v7
     permissions:
       actions: read
       contents: write
       security-events: write
       id-token: write
+    if: "(github.ref_name == 'main') || contains(github.event.head_commit.message, 'deploy:dev')"
+    uses: navikt/pam-deploy/.github/workflows/deploy-dev.yml@v7
     with:
-      JAVA_VERSION: 17
+      JAVA_VERSION: 21
       NAIS_RESOURCE: .nais/naiserator.yml
       NAIS_VARS: .nais/naiserator-dev.json
+      SKIP_DRAFT_RELEASE: ${{ github.ref_name != 'main' }}
     secrets:
       NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.nais/naiserator-dev.json
+++ b/.nais/naiserator-dev.json
@@ -1,3 +1,4 @@
 {
-  "ingress": ["https://pam-emailer.intern.dev.nav.no"]
+  "ingress": ["https://pam-emailer.intern.dev.nav.no"],
+  "database_tier": "db-f1-micro"
 }

--- a/.nais/naiserator-prod.json
+++ b/.nais/naiserator-prod.json
@@ -1,3 +1,4 @@
 {
-  "ingress": ["https://pam-emailer.intern.nav.no"]
+  "ingress": ["https://pam-emailer.intern.nav.no"],
+  "database_tier": "db-custom-1-3840"
 }

--- a/.nais/naiserator.yml
+++ b/.nais/naiserator.yml
@@ -46,6 +46,13 @@ spec:
   {{/each}}
   envFrom:
     - secret: pam-emailer
+  gcp:
+    sqlInstances:
+      - type: POSTGRES_16
+        tier: {{database_tier}}
+        databases:
+          - name: pam-emailer-db
+            envVarPrefix: DB
   accessPolicy:
     inbound:
       rules:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,10 +28,11 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.micrometer:micrometer-core")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
-
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
+    implementation("net.javacrumbs.shedlock:shedlock-spring:6.0.2")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.0.2")
 
     implementation("com.azure:azure-identity:1.14.2")
     implementation("com.microsoft.graph:microsoft-graph:6.21.0")
@@ -46,6 +47,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("io.mockk:mockk:1.13.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("io.mockk:mockk:1.13.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,17 @@ java {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.micrometer:micrometer-core")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
+    runtimeOnly("org.postgresql:postgresql")
 
     implementation("com.azure:azure-identity:1.14.2")
     implementation("com.microsoft.graph:microsoft-graph:6.21.0")
@@ -37,6 +42,9 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+networks:
+  default:
+    name: pam-shared-network
+    external: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.daemon.jvmargs=-Xmx1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.daemon.jvmargs=-Xmx1024m
+kotlin.daemon.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,0 @@
-micronautVersion=3.7.4
-kotlinVersion=1.6.20
-kapt.incremental.apt=false
-logbackVersion=1.2.11
-logbackEncoderVersion=6.6
-jacksonVersion=2.13.0
-johnrengelmanShadowVersion=7.1.0
-adal4jVersion=1.6.7

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
@@ -31,10 +31,10 @@ class SendMailController(private val emailService: EmailService) {
     fun sendMail(@RequestBody emailDto: EmailDTO): ResponseEntity<Void> {
         val id = if (emailDto.identifier == null) {
             val identifier = UUID.randomUUID().toString()
-            LOG.info("Got email request without identifier, adding new identifier: $identifier")
+            LOG.info("New email request without identifier, adding new id $identifier")
             identifier
         } else {
-            LOG.info("Got email request with identifier: ${emailDto.identifier}")
+            LOG.info("New email request with id ${emailDto.identifier}")
             emailDto.identifier
         }
 
@@ -53,7 +53,7 @@ class SendMailController(private val emailService: EmailService) {
 
     @ExceptionHandler(SendMailException::class)
     fun handleSendMailException(exception: SendMailException): ResponseEntity<String> {
-        LOG.error("We got error while sending email", exception)
+        LOG.error("Error while sending email", exception)
 
         return ResponseEntity.status(exception.status).body(exception.message)
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
@@ -1,7 +1,10 @@
 package no.nav.arbeidsplassen.emailer.api.v1
 
-import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
 import no.nav.arbeidsplassen.emailer.azure.impl.SendMailException
+import no.nav.arbeidsplassen.emailer.sendmail.Attachment
+import no.nav.arbeidsplassen.emailer.sendmail.Email
+import no.nav.arbeidsplassen.emailer.sendmail.EmailService
+import no.nav.arbeidsplassen.emailer.sendmail.Priority
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -11,27 +14,39 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
 
 @RestController
 @RequestMapping("/api/v1/sendmail")
-class SendMailController(private val emailServiceAzure: EmailServiceAzure) {
+class SendMailController(private val emailService: EmailService) {
 
     companion object {
         private val LOG = LoggerFactory.getLogger(SendMailController::class.java)
     }
 
     @PostMapping
-    fun sendMail(@RequestBody email: EmailDTO): ResponseEntity<Void> {
-        val id = if (email.identifier == null) {
+    @OptIn(ExperimentalEncodingApi::class)
+    fun sendMail(@RequestBody emailDto: EmailDTO): ResponseEntity<Void> {
+        val id = if (emailDto.identifier == null) {
             val identifier = UUID.randomUUID().toString()
             LOG.info("Got email request without identifier, adding new identifier: $identifier")
             identifier
         } else {
-            LOG.info("Got email request with identifier: ${email.identifier}")
-            email.identifier
+            LOG.info("Got email request with identifier: ${emailDto.identifier}")
+            emailDto.identifier
         }
 
-        emailServiceAzure.sendMail(email, id)
+        val email = Email(
+            recipient = emailDto.recipient,
+            subject = emailDto.subject,
+            content = emailDto.content,
+            type = emailDto.type,
+            attachments = emailDto.attachments.map { Attachment(it.name, it.contentType, Base64.Default.decode(it.base64Content).decodeToString()) }
+        )
+
+        emailService.sendEmail(email, id, Priority.NORMAL)
 
         return ResponseEntity.status(HttpStatus.CREATED).build()
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/api/v1/SendMailController.kt
@@ -46,7 +46,7 @@ class SendMailController(private val emailService: EmailService) {
             attachments = emailDto.attachments.map { Attachment(it.name, it.contentType, Base64.Default.decode(it.base64Content).decodeToString()) }
         )
 
-        emailService.sendEmail(email, id, Priority.NORMAL)
+        emailService.sendNewEmail(email, id, Priority.NORMAL)
 
         return ResponseEntity.status(HttpStatus.CREATED).build()
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/EmailServiceAzure.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/EmailServiceAzure.kt
@@ -53,7 +53,6 @@ class EmailServiceAzure(private val aadProperties: AzureADProperties) {
                 .post(emailRequestBody)
 
         } catch (e: ODataError) {
-            LOG.warn("Failed to send email with $id. Response code ${e.responseStatusCode}.")
             SECURE_LOG.warn("Failed to send email with $id. Response code ${e.responseStatusCode}. Message ${e.message}.", e)
 
             throw SendMailException(message = "Failed to send email with $id", status = HttpStatus.valueOf(e.responseStatusCode))

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/config/ObjectMapperConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/config/ObjectMapperConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.arbeidsplassen.emailer.config
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+@Configuration
+class ObjectMapperConfig {
+
+    @Bean
+    @Primary
+    fun objectMapper(): ObjectMapper {
+        return jacksonObjectMapper().apply {
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            registerModule(JavaTimeModule())
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/config/SchedulerConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/config/SchedulerConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.arbeidsplassen.emailer.config
+
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
+
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT1M")
+class SchedulerConfig {
+    @Bean
+    fun lockProvider(dataSource: DataSource, transactionManager: PlatformTransactionManager) =
+        JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(JdbcTemplate(dataSource))
+                .usingDbTime()
+                .build()
+        )
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/Email.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/Email.kt
@@ -14,7 +14,11 @@ data class Attachment(
     val content: String
 )
 
-enum class Priority(priority: Int) {
+enum class Priority(val value: Int) {
     HIGH(10),
-    NORMAL(5)
+    NORMAL(5);
+
+    companion object {
+        fun fromValue(value: Int) = entries.first { it.value == value }
+    }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/Email.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/Email.kt
@@ -1,0 +1,20 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+data class Email(
+    val recipient: String,
+    val subject: String,
+    val content: String,
+    val type: String,
+    val attachments: List<Attachment> = listOf()
+)
+
+data class Attachment(
+    val name: String,
+    val contentType: String,
+    val content: String
+)
+
+enum class Priority(priority: Int) {
+    HIGH(10),
+    NORMAL(5)
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailQuota.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailQuota.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service
 import kotlin.math.min
 
 @Service
-class LimitHandler(private val emailRepository: OutboxEmailRepository) {
+class EmailQuota(private val emailRepository: OutboxEmailRepository) {
     companion object {
         const val MAX_EMAILS_PER_HOUR = 2_850   // Actually 3000, but use a 5 % buffer to avoid hitting the limit
         const val HIGH_PRIORITY_EMAIL_BUFFER = 200

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailQuota.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailQuota.kt
@@ -20,7 +20,9 @@ class EmailQuota(private val emailRepository: OutboxEmailRepository) {
         const val RETRY_EMAIL_CRON = "0 */5 * * * *"
         const val RETRY_EMAIL_LOCK_AT_LEAST_FOR = "PT4M"
         const val RETRY_EMAIL_LOCK_AT_MOST_FOR = "PT20M"
-        const val MAX_RETRIES = 15
+
+        const val MAX_RETRIES_NORMAL_PRIORITY_EMAIL = 1
+        const val MAX_RETRIES_HIGH_PRIORITY_EMAIL = 50
     }
 
     fun canSendEmailNow(outboxEmail: OutboxEmail): Boolean {

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -1,0 +1,13 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
+import org.springframework.stereotype.Service
+
+@Service
+class EmailService(private val emailServiceAzure: EmailServiceAzure) {
+
+    fun sendEmail(email: Email, emailId: String, priority: Priority) {
+        emailServiceAzure.sendMail(email, emailId)
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -1,13 +1,47 @@
 package no.nav.arbeidsplassen.emailer.sendmail
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
+import no.nav.arbeidsplassen.emailer.azure.impl.SendMailException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
 
 @Service
-class EmailService(private val emailServiceAzure: EmailServiceAzure) {
+class EmailService(
+    private val emailRepository: OutboxEmailRepository,
+    private val emailServiceAzure: EmailServiceAzure,
+    private val objectMapper: ObjectMapper
+) {
+    private val limitHandler = LimitHandler(emailRepository)
 
-    fun sendEmail(email: Email, emailId: String, priority: Priority) {
-        emailServiceAzure.sendMail(email, emailId)
+    @Transactional
+    fun sendNewEmail(email: Email, emailId: String, priority: Priority) {
+        val outboxEmail = OutboxEmail.newOutboxEmail(emailId, priority, objectMapper.writeValueAsString(email))
+
+        if (limitHandler.canSendEmailNow()) {
+            try {
+                emailServiceAzure.sendMail(email, emailId)
+                outboxEmail.successfullySent()
+            } catch (e: SendMailException) {
+                outboxEmail.failedToSend()
+            }
+        }
+
+        emailRepository.create(outboxEmail)
+    }
+
+    @Transactional
+    fun sendEmail(outboxEmail: OutboxEmail) {
+        try {
+            val email = objectMapper.readValue(outboxEmail.payload, Email::class.java)
+            emailServiceAzure.sendMail(email, outboxEmail.emailId)
+            outboxEmail.successfullySent()
+        } catch (e: SendMailException) {
+            outboxEmail.failedToSend()
+        }
+
+        emailRepository.update(outboxEmail)
     }
 
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -24,7 +24,7 @@ class EmailService(
     fun sendNewEmail(email: Email, emailId: String, priority: Priority) {
         val outboxEmail = OutboxEmail.newOutboxEmail(emailId, priority, objectMapper.writeValueAsString(email))
 
-        if (limitHandler.canSendEmailNow()) {
+        if (limitHandler.canSendEmailNow(outboxEmail)) {
             try {
                 LOG.info("Sending email with id $emailId immediately")
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -44,7 +44,7 @@ class EmailService(
     }
 
     @Transactional
-    fun sendEmail(outboxEmail: OutboxEmail) {
+    fun sendExistingEmail(outboxEmail: OutboxEmail) {
         try {
             LOG.info("Sending email with id ${outboxEmail.id}. Status: ${outboxEmail.status}. Try number: ${outboxEmail.tryNumber()}.")
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -11,9 +11,9 @@ import org.springframework.transaction.annotation.Transactional
 class EmailService(
     private val emailRepository: OutboxEmailRepository,
     private val emailServiceAzure: EmailServiceAzure,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val limitHandler: LimitHandler,
 ) {
-    private val limitHandler = LimitHandler(emailRepository)
 
     @Transactional
     fun sendNewEmail(email: Email, emailId: String, priority: Priority) {
@@ -43,5 +43,4 @@ class EmailService(
 
         emailRepository.update(outboxEmail)
     }
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/EmailService.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsplassen.emailer.sendmail
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
 import no.nav.arbeidsplassen.emailer.azure.impl.SendMailException
-import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.MAX_RETRIES
+import no.nav.arbeidsplassen.emailer.sendmail.EmailQuota.Companion.MAX_RETRIES
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,7 +14,7 @@ class EmailService(
     private val emailRepository: OutboxEmailRepository,
     private val emailServiceAzure: EmailServiceAzure,
     private val objectMapper: ObjectMapper,
-    private val limitHandler: LimitHandler,
+    private val emailQuota: EmailQuota,
 ) {
     companion object {
         private val LOG = LoggerFactory.getLogger(EmailService::class.java)
@@ -24,7 +24,7 @@ class EmailService(
     fun sendNewEmail(email: Email, emailId: String, priority: Priority) {
         val outboxEmail = OutboxEmail.newOutboxEmail(emailId, priority, objectMapper.writeValueAsString(email))
 
-        if (limitHandler.canSendEmailNow(outboxEmail)) {
+        if (emailQuota.canSendEmailNow(outboxEmail)) {
             try {
                 LOG.info("Sending email with id $emailId immediately")
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandler.kt
@@ -1,13 +1,25 @@
 package no.nav.arbeidsplassen.emailer.sendmail
 
+import org.springframework.stereotype.Service
 import kotlin.math.min
 
+@Service
 class LimitHandler(private val emailRepository: OutboxEmailRepository) {
     companion object {
         const val MAX_EMAILS_PER_HOUR = 2_850   // Actually 3000, but use a 5 % buffer to avoid hitting the limit
-        const val PENDING_EMAIL_BATCH_SIZE = 20
-        const val RETRY_EMAIL_BATCH_SIZE = 20
-        const val MAX_RETRIES_PER_EMAIL = 25
+
+        // 10 every 10 seconds = max 3600 per hour
+        const val PENDING_EMAIL_BATCH_SIZE = 10
+        const val PENDING_EMAIL_CRON = "*/10 * * * * *"
+        const val PENDING_EMAIL_LOCK_AT_LEAST_FOR = "PT8S"
+        const val PENDING_EMAIL_LOCK_AT_MOST_FOR = "PT5M"
+
+        // 100 every 5 minutes = max 1200 per hour
+        const val RETRY_EMAIL_BATCH_SIZE = 100
+        const val RETRY_EMAIL_CRON = "0 */5 * * * *"
+        const val RETRY_EMAIL_LOCK_AT_LEAST_FOR = "PT4M"
+        const val RETRY_EMAIL_LOCK_AT_MOST_FOR = "PT20M"
+        const val MAX_RETRIES = 15
     }
 
     fun canSendEmailNow(): Boolean {

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandler.kt
@@ -1,0 +1,39 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import kotlin.math.min
+
+class LimitHandler(private val emailRepository: OutboxEmailRepository) {
+    companion object {
+        const val MAX_EMAILS_PER_HOUR = 2_850   // Actually 3000, but use a 5 % buffer to avoid hitting the limit
+        const val PENDING_EMAIL_BATCH_SIZE = 20
+        const val RETRY_EMAIL_BATCH_SIZE = 20
+        const val MAX_RETRIES_PER_EMAIL = 25
+    }
+
+    fun canSendEmailNow(): Boolean {
+        val emailsSentInLastHour = emailRepository.countEmailsSentInLastHour()
+        return emailsSentInLastHour < MAX_EMAILS_PER_HOUR
+    }
+
+    fun emailsToSend(): Int {
+        val emailsSentInLastHour = emailRepository.countEmailsSentInLastHour()
+        val emailsLeftToSendThisHour = MAX_EMAILS_PER_HOUR - emailsSentInLastHour
+
+        return if (emailsLeftToSendThisHour <= 0) {
+            0
+        } else {
+            min(emailsLeftToSendThisHour, PENDING_EMAIL_BATCH_SIZE)
+        }
+    }
+
+    fun emailsToRetry(): Int {
+        val emailsSentInLastHour = emailRepository.countEmailsSentInLastHour()
+        val emailsLeftToSendThisHour = MAX_EMAILS_PER_HOUR - emailsSentInLastHour
+
+        return if (emailsLeftToSendThisHour <= 0) {
+            0
+        } else {
+            min(emailsLeftToSendThisHour, RETRY_EMAIL_BATCH_SIZE)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmail.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmail.kt
@@ -7,12 +7,12 @@ import java.util.*
 data class OutboxEmail(
     val id: UUID,
     val emailId: String,
-    val status: Status,
-    val priority: Priority,
+    var status: Status,
+    var priority: Priority,
     val createdAt: OffsetDateTime,
-    val updatedAt: OffsetDateTime,
-    val retries: Int,
-    val payload: String
+    var updatedAt: OffsetDateTime,
+    var retries: Int,
+    var payload: String
 ) {
     companion object {
         fun newOutboxEmail(emailId: String, priority: Priority, payload: String): OutboxEmail {
@@ -28,6 +28,18 @@ data class OutboxEmail(
                 payload = payload
             )
         }
+    }
+
+    fun successfullySent() {
+        status = Status.SENT
+        updatedAt = OffsetDateTime.now()
+        payload = ""
+    }
+
+    fun failedToSend() {
+        status = Status.FAILED
+        updatedAt = OffsetDateTime.now()
+        retries++
     }
 }
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmail.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmail.kt
@@ -1,0 +1,38 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import java.time.OffsetDateTime
+import java.util.*
+
+
+data class OutboxEmail(
+    val id: UUID,
+    val emailId: String,
+    val status: Status,
+    val priority: Priority,
+    val createdAt: OffsetDateTime,
+    val updatedAt: OffsetDateTime,
+    val retries: Int,
+    val payload: String
+) {
+    companion object {
+        fun newOutboxEmail(emailId: String, priority: Priority, payload: String): OutboxEmail {
+            val now = OffsetDateTime.now()
+            return OutboxEmail(
+                id = UUID.randomUUID(),
+                emailId = emailId,
+                status = Status.PENDING,
+                priority = priority,
+                createdAt = now,
+                updatedAt = now,
+                retries = 0,
+                payload = payload
+            )
+        }
+    }
+}
+
+enum class Status {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsplassen.emailer.sendmail
 
-import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.MAX_RETRIES
+import no.nav.arbeidsplassen.emailer.sendmail.EmailQuota.Companion.MAX_RETRIES
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
@@ -1,0 +1,73 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.*
+
+
+@Repository
+class OutboxEmailRepository(val jdbcTemplate: NamedParameterJdbcTemplate) {
+
+    fun create(outboxEmail: OutboxEmail) {
+        val sql = """
+            INSERT INTO outbox_email (
+                id,
+                email_id,
+                status,
+                priority,
+                created_at,
+                updated_at,
+                retries,
+                payload
+            )
+            VALUES (
+                :id,
+                :email_id,
+                :status,
+                :priority,
+                :created_at,
+                :updated_at,
+                :retries,
+                :payload
+            )
+        """.trimIndent()
+        val params = MapSqlParameterSource()
+            .addValue("id", outboxEmail.id)
+            .addValue("email_id", outboxEmail.emailId)
+            .addValue("status", outboxEmail.status.toString())
+            .addValue("priority", outboxEmail.priority.value)
+            .addValue("created_at", outboxEmail.createdAt)
+            .addValue("updated_at", outboxEmail.updatedAt)
+            .addValue("retries", outboxEmail.retries)
+            .addValue("payload", outboxEmail.payload)
+
+        jdbcTemplate.update(sql, params)
+    }
+
+    fun findById(id: UUID): OutboxEmail? {
+        val sql = """
+            SELECT *
+            FROM outbox_email
+            WHERE id = :id
+        """.trimIndent()
+        val params = MapSqlParameterSource("id", id)
+
+        return jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+            OutboxEmail(
+                id = rs.getObject("id", UUID::class.java),
+                emailId = rs.getString("email_id"),
+                status = Status.valueOf(rs.getString("status")),
+                priority = Priority.fromValue(rs.getInt("priority")),
+                createdAt = rs.getObject("created_at", OffsetDateTime::class.java),
+                updatedAt = rs.getObject("updated_at", OffsetDateTime::class.java),
+                retries = rs.getInt("retries"),
+                payload = rs.getString("payload")
+            )
+        }
+    }
+
+}
+

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepository.kt
@@ -71,12 +71,12 @@ class OutboxEmailRepository(val jdbcTemplate: NamedParameterJdbcTemplate) {
         return jdbcTemplate.queryForObject(sql, params, rowMapper)
     }
 
-    fun findPendingSortedByCreated(limit: Int): List<OutboxEmail> {
+    fun findPendingSortedByPriorityAndCreated(limit: Int): List<OutboxEmail> {
         val sql = """
             SELECT *
             FROM outbox_email
             WHERE status = :pending_status
-            ORDER BY created_at
+            ORDER BY priority DESC, created_at
             LIMIT :limit
         """.trimIndent()
 
@@ -87,13 +87,13 @@ class OutboxEmailRepository(val jdbcTemplate: NamedParameterJdbcTemplate) {
         return jdbcTemplate.query(sql, params, rowMapper)
     }
 
-    fun findFailedSortedByUpdated(limit: Int): List<OutboxEmail> {
+    fun findFailedSortedByPriorityAndUpdated(limit: Int): List<OutboxEmail> {
         val sql = """
             SELECT *
             FROM outbox_email
             WHERE status = :failed_status
              AND retries < :max_retries
-            ORDER BY updated_at
+            ORDER BY priority DESC, updated_at
             LIMIT :limit
         """.trimIndent()
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailDeleter.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailDeleter.kt
@@ -1,0 +1,16 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class ScheduledOutboxEmailDeleter(private val outboxEmailRepository: OutboxEmailRepository) {
+
+    @Scheduled(cron = "0 0 * * * *")
+    @SchedulerLock(name = "deleteSentEmails", lockAtLeastFor = "PT10S", lockAtMostFor = "PT5M")
+    fun deleteSentEmails() {
+        outboxEmailRepository.deleteEmailsOlderThanAnHour()
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
@@ -41,7 +41,7 @@ class ScheduledOutboxEmailSender(
             LOG.info("Sending ${emails.size} pending emails (max batch size was ${batchSize.numberOfEmails})")
 
             emails.forEach {
-                emailService.sendEmail(it)
+                emailService.sendExistingEmail(it)
             }
         }
     }
@@ -62,7 +62,7 @@ class ScheduledOutboxEmailSender(
             LOG.info("Retrying ${emails.size} failed emails (max batch size was ${batchSize.numberOfEmails})")
 
             emails.forEach {
-                emailService.sendEmail(it)
+                emailService.sendExistingEmail(it)
             }
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
@@ -35,7 +35,7 @@ class ScheduledOutboxEmailSender(
             return
         }
 
-        val emails = outboxEmailRepository.findPendingSortedByPriorityAndCreated(batchSize.numberOfEmails)
+        val emails = outboxEmailRepository.findPendingSortedByPriorityAndCreated(batchSize.numberOfEmails, batchSize.highPriorityOnly)
 
         if (emails.isNotEmpty()) {
             LOG.info("Sending ${emails.size} pending emails (max batch size was ${batchSize.numberOfEmails})")
@@ -56,7 +56,7 @@ class ScheduledOutboxEmailSender(
             return
         }
 
-        val emails = outboxEmailRepository.findFailedSortedByPriorityAndUpdated(batchSize.numberOfEmails)
+        val emails = outboxEmailRepository.findFailedSortedByPriorityAndUpdated(batchSize.numberOfEmails, batchSize.highPriorityOnly)
 
         if (emails.isNotEmpty()) {
             LOG.info("Retrying ${emails.size} failed emails (max batch size was ${batchSize.numberOfEmails})")

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
@@ -35,7 +35,7 @@ class ScheduledOutboxEmailSender(
             return
         }
 
-        val emails = outboxEmailRepository.findPendingSortedByCreated(numberOfEmailsToSend)
+        val emails = outboxEmailRepository.findPendingSortedByPriorityAndCreated(numberOfEmailsToSend)
 
         if (emails.isNotEmpty()) {
             LOG.info("Sending ${emails.size} pending emails (max batch size was $numberOfEmailsToSend)")
@@ -56,7 +56,7 @@ class ScheduledOutboxEmailSender(
             return
         }
 
-        val emails = outboxEmailRepository.findFailedSortedByUpdated(numberOfEmailsToSend)
+        val emails = outboxEmailRepository.findFailedSortedByPriorityAndUpdated(numberOfEmailsToSend)
 
         if (emails.isNotEmpty()) {
             LOG.info("Retrying ${emails.size} failed emails (max batch size was $numberOfEmailsToSend)")

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
@@ -31,14 +31,14 @@ class ScheduledOutboxEmailSender(
         val numberOfEmailsToSend = limitHandler.emailsToSend()
 
         if (numberOfEmailsToSend == 0) {
-            LOG.info("No quota left for sending emails")
+            LOG.debug("No quota left for sending emails")
             return
         }
 
         val emails = outboxEmailRepository.findPendingSortedByCreated(numberOfEmailsToSend)
 
         if (emails.isNotEmpty()) {
-            LOG.info("Sending ${emails.size} emails (max batch size was $numberOfEmailsToSend)")
+            LOG.info("Sending ${emails.size} pending emails (max batch size was $numberOfEmailsToSend)")
 
             emails.forEach {
                 emailService.sendEmail(it)
@@ -52,7 +52,7 @@ class ScheduledOutboxEmailSender(
         val numberOfEmailsToSend = limitHandler.emailsToRetry()
 
         if (numberOfEmailsToSend == 0) {
-            LOG.info("No quota left for retrying failed emails")
+            LOG.debug("No quota left for retrying failed emails")
             return
         }
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/sendmail/ScheduledOutboxEmailSender.kt
@@ -1,0 +1,69 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.PENDING_EMAIL_CRON
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.PENDING_EMAIL_LOCK_AT_LEAST_FOR
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.PENDING_EMAIL_LOCK_AT_MOST_FOR
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.RETRY_EMAIL_CRON
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.RETRY_EMAIL_LOCK_AT_LEAST_FOR
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.RETRY_EMAIL_LOCK_AT_MOST_FOR
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class ScheduledOutboxEmailSender(
+    private val emailService: EmailService,
+    private val limitHandler: LimitHandler,
+    private val outboxEmailRepository: OutboxEmailRepository
+) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ScheduledOutboxEmailSender::class.java)
+    }
+
+    @Scheduled(cron = PENDING_EMAIL_CRON)
+    @SchedulerLock(
+        name = "sendPendingEmails",
+        lockAtLeastFor = PENDING_EMAIL_LOCK_AT_LEAST_FOR,
+        lockAtMostFor = PENDING_EMAIL_LOCK_AT_MOST_FOR
+    )
+    fun sendPendingEmails() {
+        val numberOfEmailsToSend = limitHandler.emailsToSend()
+
+        if (numberOfEmailsToSend == 0) {
+            LOG.info("No quota left for sending emails")
+            return
+        }
+
+        val emails = outboxEmailRepository.findPendingSortedByCreated(numberOfEmailsToSend)
+
+        if (emails.isNotEmpty()) {
+            LOG.info("Sending ${emails.size} emails (max batch size was $numberOfEmailsToSend)")
+
+            emails.forEach {
+                emailService.sendEmail(it)
+            }
+        }
+    }
+
+    @Scheduled(cron = RETRY_EMAIL_CRON)
+    @SchedulerLock(name = "retryFailedEmails", lockAtLeastFor = RETRY_EMAIL_LOCK_AT_LEAST_FOR, lockAtMostFor = RETRY_EMAIL_LOCK_AT_MOST_FOR)
+    fun retryFailedEmails() {
+        val numberOfEmailsToSend = limitHandler.emailsToRetry()
+
+        if (numberOfEmailsToSend == 0) {
+            LOG.info("No quota left for retrying failed emails")
+            return
+        }
+
+        val emails = outboxEmailRepository.findFailedSortedByUpdated(numberOfEmailsToSend)
+
+        if (emails.isNotEmpty()) {
+            LOG.info("Retrying ${emails.size} failed emails (max batch size was $numberOfEmailsToSend)")
+
+            emails.forEach {
+                emailService.sendEmail(it)
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:35432}/${DB_DATABASE:pam-emailer}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:password}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: pam-emailer
 
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:}:${DB_PORT:}/${DB_DATABASE:}
+    username: ${DB_USERNAME:}
+    password: ${DB_PASSWORD:}
+
 management:
   endpoints.web.exposure.include: prometheus
   endpoint:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,7 @@ spring:
     name: pam-emailer
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${db.jdbc.url}
     hikari:
       minimum-idle: 5
       maximum-pool-size: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: pam-emailer
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST:}:${DB_PORT:}/${DB_DATABASE:}
-    username: ${DB_USERNAME:}
-    password: ${DB_PASSWORD:}
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     hikari:
       minimum-idle: 5
       maximum-pool-size: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
     url: jdbc:postgresql://${DB_HOST:}:${DB_PORT:}/${DB_DATABASE:}
     username: ${DB_USERNAME:}
     password: ${DB_PASSWORD:}
+    hikari:
+      minimum-idle: 5
+      maximum-pool-size: 5
 
 management:
   endpoints.web.exposure.include: prometheus

--- a/src/main/resources/db/migration/V001__outbox_email.sql
+++ b/src/main/resources/db/migration/V001__outbox_email.sql
@@ -1,0 +1,11 @@
+CREATE TABLE outbox_email
+(
+    id         UUID PRIMARY KEY,
+    email_id   TEXT                     NOT NULL,
+    status     TEXT                     NOT NULL,
+    priority   INTEGER                  NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    retries    INTEGER                  NOT NULL,
+    payload    TEXT                     NOT NULL
+);

--- a/src/main/resources/db/migration/V002__shedlock.sql
+++ b/src/main/resources/db/migration/V002__shedlock.sql
@@ -1,0 +1,7 @@
+CREATE TABLE shedlock
+(
+    name       VARCHAR(64)  NOT NULL PRIMARY KEY,
+    lock_until TIMESTAMP    NOT NULL,
+    locked_at  TIMESTAMP    NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL
+);

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/PostgresTestDatabase.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/PostgresTestDatabase.kt
@@ -1,0 +1,33 @@
+package no.nav.arbeidsplassen.emailer
+
+import org.junit.jupiter.api.BeforeAll
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+abstract class PostgresTestDatabase {
+    companion object {
+        val db: PostgreSQLContainer<*> = PostgreSQLContainer<Nothing>("postgres:16-alpine")
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("username")
+                withPassword("password")
+            }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", db::getJdbcUrl)
+            registry.add("spring.datasource.password", db::getPassword)
+            registry.add("spring.datasource.username", db::getUsername)
+        }
+
+        @JvmStatic
+        @BeforeAll
+        internal fun setUp() {
+            db.start()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/azure/EmailerIT.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/azure/EmailerIT.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsplassen.emailer.azure
 
 import no.nav.arbeidsplassen.emailer.api.v1.AttachmentDto
 import no.nav.arbeidsplassen.emailer.api.v1.EmailDTO
-import no.nav.arbeidsplassen.emailer.azure.impl.EmailServiceAzure
+import no.nav.arbeidsplassen.emailer.api.v1.SendMailController
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,7 +14,7 @@ import java.util.*
 class EmailerIT {
 
     @Autowired
-    private lateinit var emailServiceAzure: EmailServiceAzure
+    private lateinit var sendMailController: SendMailController
 
     @Test
     fun sendEmailAzure() {
@@ -26,7 +26,7 @@ class EmailerIT {
             type = "TEXT"
         )
 
-        emailServiceAzure.sendMail(email, "hei hei")
+        sendMailController.sendMail(email)
     }
 
     @Test
@@ -40,6 +40,6 @@ class EmailerIT {
             attachments = listOf(AttachmentDto("test.txt", "plain/text", Base64.getEncoder().encodeToString("Hei!".encodeToByteArray())))
         )
 
-        emailServiceAzure.sendMail(email, "hei hei")
+        sendMailController.sendMail(email)
     }
 }

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandlerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/LimitHandlerTest.kt
@@ -1,0 +1,73 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.MAX_EMAILS_PER_HOUR
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.PENDING_EMAIL_BATCH_SIZE
+import no.nav.arbeidsplassen.emailer.sendmail.LimitHandler.Companion.RETRY_EMAIL_BATCH_SIZE
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class LimitHandlerTest {
+
+    private val emailRepository = mockk<OutboxEmailRepository>()
+    private val limitHandler: LimitHandler = LimitHandler(emailRepository)
+
+    @Test
+    fun `Can send emails when not hitting limit`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns 0
+
+        assertTrue(limitHandler.canSendEmailNow())
+    }
+
+    @Test
+    fun `Can not send emails when limit is hit`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR + 1
+
+        assertFalse(limitHandler.canSendEmailNow())
+    }
+
+    @Test
+    fun `Will return pending email batch size, when there are more emails than batch size left to send`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR - PENDING_EMAIL_BATCH_SIZE - 10
+
+        assertEquals(PENDING_EMAIL_BATCH_SIZE, limitHandler.emailsToSend())
+    }
+
+    @Test
+    fun `Will return 0 emails to send when there are no more emails to send`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR
+
+        assertEquals(0, limitHandler.emailsToSend())
+    }
+
+    @Test
+    fun `Will return count of emails left to send, when there are less than batch size emails left to send`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR - PENDING_EMAIL_BATCH_SIZE + 5
+
+        assertEquals(PENDING_EMAIL_BATCH_SIZE - 5, limitHandler.emailsToSend())
+    }
+
+    @Test
+    fun `Will return retry email batch size, when there are more emails than batch size left to send`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR - RETRY_EMAIL_BATCH_SIZE - 10
+
+        assertEquals(RETRY_EMAIL_BATCH_SIZE, limitHandler.emailsToRetry())
+    }
+
+    @Test
+    fun `Will return 0 emails to send when there are no more emails to retry`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR
+
+        assertEquals(0, limitHandler.emailsToRetry())
+    }
+
+    @Test
+    fun `Will return count of emails left to retry, when there are less than batch size emails left to retry`() {
+        every { emailRepository.countEmailsSentInLastHour() } returns MAX_EMAILS_PER_HOUR - PENDING_EMAIL_BATCH_SIZE + 5
+
+        assertEquals(PENDING_EMAIL_BATCH_SIZE - 5, limitHandler.emailsToRetry())
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepositoryTest.kt
@@ -1,0 +1,45 @@
+package no.nav.arbeidsplassen.emailer.sendmail
+
+import no.nav.arbeidsplassen.emailer.PostgresTestDatabase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+import kotlin.test.assertEquals
+
+@SpringBootTest
+class OutboxEmailRepositoryTest : PostgresTestDatabase() {
+
+    @Autowired
+    lateinit var outboxEmailRepository: OutboxEmailRepository
+
+    @Test
+    fun `E-mails are stored and read correctly`() {
+        val email = OutboxEmail(
+            id = UUID.randomUUID(),
+            emailId = UUID.randomUUID().toString(),
+            status = Status.PENDING,
+            priority = Priority.NORMAL,
+            createdAt = OffsetDateTime.now().minusHours(1),
+            updatedAt = OffsetDateTime.now(),
+            retries = 0,
+            payload = "payload"
+        )
+
+        outboxEmailRepository.create(email)
+
+        val storedEmail = outboxEmailRepository.findById(email.id)!!
+
+        assertEquals(email.id, storedEmail.id)
+        assertEquals(email.emailId, storedEmail.emailId)
+        assertEquals(email.status, storedEmail.status)
+        assertEquals(email.priority, storedEmail.priority)
+        assertThat(email.createdAt.truncatedTo(ChronoUnit.MILLIS)).isEqualTo(storedEmail.createdAt.truncatedTo(ChronoUnit.MILLIS))
+        assertThat(email.updatedAt.truncatedTo(ChronoUnit.MILLIS)).isEqualTo(storedEmail.updatedAt.truncatedTo(ChronoUnit.MILLIS))
+        assertEquals(email.retries, storedEmail.retries)
+        assertEquals(email.payload, storedEmail.payload)
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/emailer/sendmail/OutboxEmailRepositoryTest.kt
@@ -2,9 +2,11 @@ package no.nav.arbeidsplassen.emailer.sendmail
 
 import no.nav.arbeidsplassen.emailer.PostgresTestDatabase
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
@@ -14,7 +16,15 @@ import kotlin.test.assertEquals
 class OutboxEmailRepositoryTest : PostgresTestDatabase() {
 
     @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
     lateinit var outboxEmailRepository: OutboxEmailRepository
+
+    @BeforeEach
+    fun cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM outbox_email")
+    }
 
     @Test
     fun `E-mails are stored and read correctly`() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+azure:
+  ad:
+    tenantId: "test"
+    authority: "test"
+    clientId: "test"
+    clientSecret: "test"
+    resource: "test"
+    userPrincipal: "test"

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Pull latest version
+git -C ../pam-docker-compose-shared pull
+
+# Start shared docker compose services (must be sourced, or DOCKER_COMPOSE_COMMAND won't be available)
+. ../pam-docker-compose-shared/start-docker-compose.sh postgres
+
+# Create database
+../pam-docker-compose-shared/create-database.sh "pam-emailer"
+
+$DOCKER_COMPOSE_COMMAND up --remove-orphans


### PR DESCRIPTION
We have a quota of 3 000 emails to send per hour in Azure. We have been locked out of our account when we have exceeded that amount. We are also lacking a good retry mechanism for when the Azure Graph API is down.

This PR adds functionality for:
* Making sure we're not sending more than 3 000 emails per hour
* Intermediate storage of emails if limit is exceeded or email fails, allowing them being sent or retried later
* Retrying failed emails
* High and normal priority emails, allowing high priority emails to be sent before normal priority (i.e. superrask søknad emails are more important than stored searches)