### PR TITLE
Delete all Azure account emails nightly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
     implementation("net.javacrumbs.shedlock:shedlock-spring:6.0.2")
     implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.0.2")
 
-    implementation("com.azure:azure-identity:1.14.2")
-    implementation("com.microsoft.graph:microsoft-graph:6.21.0")
+    implementation("com.azure:azure-identity:1.15.4")
+    implementation("com.microsoft.graph:microsoft-graph:6.33.0")
 
     implementation("org.codehaus.janino:janino:3.1.10")
     implementation("net.logstash.logback:logstash-logback-encoder:6.6")

--- a/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/ScheduledEmailDeleter.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/emailer/azure/impl/ScheduledEmailDeleter.kt
@@ -1,0 +1,16 @@
+package no.nav.arbeidsplassen.emailer.azure.impl
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class ScheduledEmailDeleter(private val emailServiceAzure: EmailServiceAzure) {
+
+    @Scheduled(cron = "0 0 1 * * *")
+    @SchedulerLock(name = "deleteAzureAccountEmails", lockAtLeastFor = "PT10S", lockAtMostFor = "PT5M")
+    fun deleteSentEmails() {
+        emailServiceAzure.deleteAllEmailsInAccount()
+    }
+
+}


### PR DESCRIPTION
Delete emails from all mailboxes in Azure account every night at 01.00, to avoid exceeding storage quota limit.

Sent and incoming e-mails seem to not be removed immediately, but placed in the deleted folder, where they count towards the quota. This will clean up that folder as well as any other e-mails in the no-reply account, thus avoiding reaching any limit.